### PR TITLE
Add alert pagination in dashboard

### DIFF
--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -244,6 +244,27 @@ h1, h2, h3 {
     font-weight: bold;
 }
 
+/* === Paginación de alertas === */
+.pagination {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.pagination button {
+    padding: 6px 12px;
+    border: 1px solid #cbd5e1;
+    background-color: white;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.pagination button[disabled] {
+    opacity: 0.5;
+    cursor: default;
+}
+
 /* ====================
    📱 Responsive
 ==================== */

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -62,6 +62,7 @@
     <div id="alertas-container">
         <p>Cargando alertas...</p>
     </div>
+    <div id="alertas-pagination" class="pagination"></div>
 </div>
 
 <script>
@@ -127,43 +128,73 @@ function cargarDashboard() {
         .then(res => res.json())
         .then(alertas => {
             const alertasDiv = document.getElementById("alertas-container");
+            const pagDiv = document.getElementById("alertas-pagination");
             if (alertas.length === 0) {
                 alertasDiv.innerHTML = "<p>✅ No hay alertas activas.</p>";
+                pagDiv.innerHTML = "";
                 return;
             }
 
-            let html = `
-            <table class="alert-table">
-                <thead>
+            const itemsPorPagina = 5;
+            let paginaActual = 1;
+            const totalPaginas = Math.ceil(alertas.length / itemsPorPagina);
+
+            function render() {
+                let html = `
+                <table class="alert-table">
+                    <thead>
+                        <tr>
+                            <th>Fecha</th>
+                            <th>Estación</th>
+                            <th>Sensor</th>
+                            <th>Tipo</th>
+                            <th>Valor</th>
+                            <th>Mensaje</th>
+                        </tr>
+                    </thead>
+                    <tbody>`;
+
+                const start = (paginaActual - 1) * itemsPorPagina;
+                alertas.slice(start, start + itemsPorPagina).forEach(a => {
+                    html += `
                     <tr>
-                        <th>Fecha</th>
-                        <th>Estación</th>
-                        <th>Sensor</th>
-                        <th>Tipo</th>
-                        <th>Valor</th>
-                        <th>Mensaje</th>
-                    </tr>
-                </thead>
-                <tbody>
-            `;
+                        <td>${new Date(a.fecha).toLocaleString()}</td>
+                        <td>${a.nombreEstacion}</td>
+                        <td>${a.sensorNombre}</td>
+                        <td>${a.tipoSensor}</td>
+                        <td>${a.valor}</td>
+                        <td>${a.mensaje}</td>
+                    </tr>`;
+                });
 
-            alertas.forEach(a => {
-                html += `
-                <tr>
-                    <td>${new Date(a.fecha).toLocaleString()}</td>
-                    <td>${a.nombreEstacion}</td>
-                    <td>${a.sensorNombre}</td>
-                    <td>${a.tipoSensor}</td>
-                    <td>${a.valor}</td>
-                    <td>${a.mensaje}</td>
-                </tr>`;
-            });
+                html += `</tbody></table>`;
+                alertasDiv.innerHTML = html;
 
-            html += `</tbody></table>`;
-            alertasDiv.innerHTML = html;
+                let pagHtml = `
+                    <button class="prev-page" ${paginaActual === 1 ? 'disabled' : ''}>Anterior</button>
+                    <span>${paginaActual} / ${totalPaginas}</span>
+                    <button class="next-page" ${paginaActual === totalPaginas ? 'disabled' : ''}>Siguiente</button>`;
+                pagDiv.innerHTML = pagHtml;
+
+                pagDiv.querySelector('.prev-page').onclick = () => {
+                    if (paginaActual > 1) {
+                        paginaActual--;
+                        render();
+                    }
+                };
+                pagDiv.querySelector('.next-page').onclick = () => {
+                    if (paginaActual < totalPaginas) {
+                        paginaActual++;
+                        render();
+                    }
+                };
+            }
+
+            render();
         })
         .catch(err => {
             document.getElementById("alertas-container").innerHTML = "<p>Error cargando alertas.</p>";
+            document.getElementById("alertas-pagination").innerHTML = "";
             console.error(err);
         });
 }


### PR DESCRIPTION
## Summary
- add pagination container to dashboard alert section
- implement client-side pagination logic
- style pagination controls

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687588a781b08328ad85610bbc2107fa