### PR TITLE
Fix dashboard station listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
 
     implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'

--- a/src/main/java/org/javadominicano/cmp/CmpApplication.java
+++ b/src/main/java/org/javadominicano/cmp/CmpApplication.java
@@ -3,8 +3,10 @@ package org.javadominicano.cmp;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CmpApplication implements CommandLineRunner {
 
     public static void main(String[] args) {

--- a/src/main/java/org/javadominicano/cmp/config/DashboardBroadcastService.java
+++ b/src/main/java/org/javadominicano/cmp/config/DashboardBroadcastService.java
@@ -1,0 +1,38 @@
+package org.javadominicano.cmp.config;
+
+import org.javadominicano.cmp.EstacionController;
+import org.javadominicano.cmp.dto.AlertaDTO;
+import org.javadominicano.cmp.dto.StationStatusDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@EnableScheduling
+public class DashboardBroadcastService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final EstacionController estacionController;
+    private final long rateMs;
+
+    public DashboardBroadcastService(SimpMessagingTemplate messagingTemplate,
+                                     EstacionController estacionController,
+                                     @Value("${broadcast.fixed-rate-ms:1000}") long rateMs) {
+        this.messagingTemplate = messagingTemplate;
+        this.estacionController = estacionController;
+        this.rateMs = rateMs;
+    }
+
+    @Scheduled(fixedRateString = "${broadcast.fixed-rate-ms:1000}")
+    public void sendUpdates() {
+        List<StationStatusDTO> status = estacionController.getStationStatusSummary();
+        messagingTemplate.convertAndSend("/topic/status", status);
+
+        List<AlertaDTO> alertas = estacionController.obtenerAlertas();
+        messagingTemplate.convertAndSend("/topic/alertas", alertas);
+    }
+}

--- a/src/main/java/org/javadominicano/cmp/config/WebSocketConfig.java
+++ b/src/main/java/org/javadominicano/cmp/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package org.javadominicano.cmp.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/org/javadominicano/cmp/controller/LoginController.java
+++ b/src/main/java/org/javadominicano/cmp/controller/LoginController.java
@@ -12,6 +12,6 @@ public class LoginController {
 
     @GetMapping("/dashboard")
     public String dashboard() {
-        return "dashboard";
+        return "redirect:/dashboard/estaciones";
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Desactivar el cache de plantillas Thymeleaf para desarrollo
 spring.thymeleaf.cache=false
+
+# Intervalo en milisegundos para enviar actualizaciones al dashboard
+broadcast.fixed-rate-ms=1000

--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -244,6 +244,27 @@ h1, h2, h3 {
     font-weight: bold;
 }
 
+/* === Paginación de alertas === */
+.pagination {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.pagination button {
+    padding: 6px 12px;
+    border: 1px solid #cbd5e1;
+    background-color: white;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.pagination button[disabled] {
+    opacity: 0.5;
+    cursor: default;
+}
+
 /* ====================
    📱 Responsive
 ==================== */

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <title>Dashboard | WeatherNet</title>
     <link rel="stylesheet" href="/css/dashboard.css" />
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2/dist/stomp.min.js"></script>
 </head>
 <body>
 <div class="sidebar">
@@ -48,7 +50,25 @@
 
     <!-- 🌐 Estaciones por tarjeta -->
     <h2 style="margin-top: 2rem;">Estaciones Meteorológicas</h2>
-    <div id="summary" class="cards-container"></div>
+    <div id="summary" class="cards-container">
+        <div th:each="est : ${resumen}"
+             th:class="${'station-card' + (est.status == 'DESCONECTADA' ? ' offline' : '')}">
+            <h3 th:text="${est.stationName}"></h3>
+            <p><strong>Estado:</strong> <span th:text="${est.status}"></span></p>
+            <p>
+                <strong>Última lectura:</strong><br>
+                <span th:text="${est.lastUpdate != null ? #dates.format(est.lastUpdate,'dd/MM/yyyy HH:mm:ss') : 'No disponible'}"></span>
+            </p>
+            <ul>
+                <li>🌡️ Temperatura: <span th:text="${est.data['temperatura']} ?: 'N/D'"></span> °C</li>
+                <li>💧 Humedad: <span th:text="${est.data['humedad']} ?: 'N/D'"></span> %</li>
+                <li>⬇️ Presión: <span th:text="${est.data['presion']} ?: 'N/D'"></span> hPa</li>
+                <li>💨 Viento: <span th:text="${est.data['viento']} ?: 'N/D'"></span> m/s</li>
+                <li>🌧️ Precipitación: <span th:text="${est.data['precipitacion']} ?: 'N/D'"></span> mm</li>
+                <li>🌱 Humedad Suelo: <span th:text="${est.data['humedad_suelo']} ?: 'N/D'"></span> %</li>
+            </ul>
+        </div>
+    </div>
 
     <!-- 🔘 Botón de actualización -->
     <div style="margin: 1rem 0;">
@@ -62,113 +82,152 @@
     <div id="alertas-container">
         <p>Cargando alertas...</p>
     </div>
+    <div id="alertas-pagination" class="pagination"></div>
 </div>
 
 <script>
+let alertasData = [];
+let paginaActual = 1;
+const itemsPorPagina = 5;
+
+function renderEstaciones(estaciones) {
+    const container = document.getElementById("summary");
+    container.innerHTML = "";
+    estaciones.forEach(est => {
+        const card = document.createElement("div");
+        card.classList.add("station-card");
+        if (est.status === "DESCONECTADA") {
+            card.classList.add("offline");
+        }
+        const ultimaLectura = est.lastUpdate ? new Date(est.lastUpdate).toLocaleString() : "No disponible";
+        card.innerHTML = `
+            <h3>${est.stationName}</h3>
+            <p><strong>Estado:</strong> ${est.status}</p>
+            <p><strong>Última lectura:</strong><br> ${ultimaLectura}</p>
+            <ul>
+                <li>🌡️ Temperatura: ${est.data?.temperatura ?? 'N/D'} °C</li>
+                <li>💧 Humedad: ${est.data?.humedad ?? 'N/D'} %</li>
+                <li>⬇️ Presión: ${est.data?.presion ?? 'N/D'} hPa</li>
+                <li>💨 Viento: ${est.data?.viento ?? 'N/D'} m/s</li>
+                <li>🌧️ Precipitación: ${est.data?.precipitacion ?? 'N/D'} mm</li>
+                <li>🌱 Humedad Suelo: ${est.data?.humedad_suelo ?? 'N/D'} %</li>
+            </ul>`;
+        container.appendChild(card);
+    });
+}
+
+function renderAlertasTabla() {
+    const alertasDiv = document.getElementById("alertas-container");
+    const pagDiv = document.getElementById("alertas-pagination");
+    if (alertasData.length === 0) {
+        alertasDiv.innerHTML = "<p>✅ No hay alertas activas.</p>";
+        pagDiv.innerHTML = "";
+        return;
+    }
+    const totalPaginas = Math.ceil(alertasData.length / itemsPorPagina);
+    let html = `
+        <table class="alert-table">
+            <thead>
+                <tr>
+                    <th>Fecha</th>
+                    <th>Estación</th>
+                    <th>Sensor</th>
+                    <th>Tipo</th>
+                    <th>Valor</th>
+                    <th>Mensaje</th>
+                </tr>
+            </thead>
+            <tbody>`;
+    const start = (paginaActual - 1) * itemsPorPagina;
+    alertasData.slice(start, start + itemsPorPagina).forEach(a => {
+        html += `
+            <tr>
+                <td>${new Date(a.fecha).toLocaleString()}</td>
+                <td>${a.nombreEstacion}</td>
+                <td>${a.sensorNombre}</td>
+                <td>${a.tipoSensor}</td>
+                <td>${a.valor}</td>
+                <td>${a.mensaje}</td>
+            </tr>`;
+    });
+    html += `</tbody></table>`;
+    alertasDiv.innerHTML = html;
+    const pagHtml = `
+        <button class="prev-page" ${paginaActual === 1 ? 'disabled' : ''}>Anterior</button>
+        <span>${paginaActual} / ${totalPaginas}</span>
+        <button class="next-page" ${paginaActual === totalPaginas ? 'disabled' : ''}>Siguiente</button>`;
+    pagDiv.innerHTML = pagHtml;
+    pagDiv.querySelector('.prev-page').onclick = () => {
+        if (paginaActual > 1) {
+            paginaActual--;
+            renderAlertasTabla();
+        }
+    };
+    pagDiv.querySelector('.next-page').onclick = () => {
+        if (paginaActual < totalPaginas) {
+            paginaActual++;
+            renderAlertasTabla();
+        }
+    };
+}
+
+function renderAlertas(alertas) {
+    alertasData = alertas;
+    paginaActual = 1;
+    renderAlertasTabla();
+}
+
 function cargarDashboard() {
-    // Resumen general
     fetch("/api/stations/summary")
-        .then(response => response.json())
+        .then(res => res.json())
         .then(data => {
             const container = document.getElementById("resumen-general");
             const html = `
                 <div class="card">Total Estaciones: ${data.total}</div>
                 <div class="card">En Línea: ${data.enLinea}</div>
                 <div class="card">Desconectadas: ${data.desconectadas}</div>
-                <div class="card alerta">Alarmas Activas: ${data.alertasActivas}</div>
-            `;
+                <div class="card alerta">Alarmas Activas: ${data.alertasActivas}</div>`;
             container.innerHTML = html;
-        }).catch(error => {
+        })
+        .catch(() => {
             document.getElementById("resumen-general").innerHTML = "<p>Error cargando datos</p>";
-            console.error(error);
         });
 
-    // Estaciones
     fetch("/api/stations/status-summary")
         .then(res => res.json())
-        .then(estaciones => {
-            const container = document.getElementById("summary");
-            container.innerHTML = "";
-
-            estaciones.forEach(est => {
-                const card = document.createElement("div");
-                card.classList.add("station-card");
-                if (est.status === "DESCONECTADA") {
-                    card.classList.add("offline");
-                }
-
-                const ultimaLectura = est.lastUpdate
-                    ? new Date(est.lastUpdate).toLocaleString()
-                    : "No disponible";
-
-                card.innerHTML = `
-                    <h3>${est.stationName}</h3>
-                    <p><strong>Estado:</strong> ${est.status}</p>
-                    <p><strong>Última lectura:</strong><br> ${ultimaLectura}</p>
-                    <ul>
-                        <li>🌡️ Temperatura: ${est.data?.temperatura ?? 'N/D'} °C</li>
-                        <li>💧 Humedad: ${est.data?.humedad ?? 'N/D'} %</li>
-                        <li>⬇️ Presión: ${est.data?.presion ?? 'N/D'} hPa</li>
-                        <li>💨 Viento: ${est.data?.viento ?? 'N/D'} m/s</li>
-                        <li>🌧️ Precipitación: ${est.data?.precipitacion ?? 'N/D'} mm</li>
-                        <li>🌱 Humedad Suelo: ${est.data?.humedad_suelo ?? 'N/D'} %</li>
-                    </ul>
-                `;
-                container.appendChild(card);
-            });
-        })
-        .catch(err => {
+        .then(renderEstaciones)
+        .catch(() => {
             document.getElementById("summary").innerHTML = "<p>Error cargando estaciones.</p>";
-            console.error(err);
         });
 
-    // Alertas
     fetch("/api/alertas")
         .then(res => res.json())
-        .then(alertas => {
-            const alertasDiv = document.getElementById("alertas-container");
-            if (alertas.length === 0) {
-                alertasDiv.innerHTML = "<p>✅ No hay alertas activas.</p>";
-                return;
-            }
-
-            let html = `
-            <table class="alert-table">
-                <thead>
-                    <tr>
-                        <th>Fecha</th>
-                        <th>Estación</th>
-                        <th>Sensor</th>
-                        <th>Tipo</th>
-                        <th>Valor</th>
-                        <th>Mensaje</th>
-                    </tr>
-                </thead>
-                <tbody>
-            `;
-
-            alertas.forEach(a => {
-                html += `
-                <tr>
-                    <td>${new Date(a.fecha).toLocaleString()}</td>
-                    <td>${a.nombreEstacion}</td>
-                    <td>${a.sensorNombre}</td>
-                    <td>${a.tipoSensor}</td>
-                    <td>${a.valor}</td>
-                    <td>${a.mensaje}</td>
-                </tr>`;
-            });
-
-            html += `</tbody></table>`;
-            alertasDiv.innerHTML = html;
-        })
-        .catch(err => {
+        .then(renderAlertas)
+        .catch(() => {
             document.getElementById("alertas-container").innerHTML = "<p>Error cargando alertas.</p>";
-            console.error(err);
+            document.getElementById("alertas-pagination").innerHTML = "";
         });
 }
 
-window.onload = cargarDashboard;
+let stompClient = null;
+
+function connectWs() {
+    const socket = new SockJS('/ws');
+    stompClient = Stomp.over(socket);
+    stompClient.connect({}, () => {
+        stompClient.subscribe('/topic/status', msg => {
+            renderEstaciones(JSON.parse(msg.body));
+        });
+        stompClient.subscribe('/topic/alertas', msg => {
+            renderAlertas(JSON.parse(msg.body));
+        });
+    });
+}
+
+window.onload = () => {
+    cargarDashboard();
+    connectWs();
+};
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redirect `/dashboard` to `/dashboard/estaciones` so templates get station data
- pre-render stations in *dashboard.html* using Thymeleaf
- configurable websocket broadcast interval

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687588a781b08328ad85610bbc2107fa