### PR TITLE
Improve alerts sidebar and dashboard summary

### DIFF
--- a/src/main/java/org/javadominicano/cmp/EstacionController.java
+++ b/src/main/java/org/javadominicano/cmp/EstacionController.java
@@ -463,6 +463,12 @@ public class EstacionController {
         dbManager.toggleSensorActivo(id);
         return "redirect:/dashboard/administrar-estaciones";
     }
+    @PostMapping("/api/alertas/manual")
+    @ResponseBody
+    public void crearAlertaManual(@RequestParam int stationId, @RequestParam int sensorId, @RequestParam double umbral, @RequestParam String mensaje) {
+        dbManager.insertAlert(stationId, sensorId, umbral, mensaje);
+    }
+
 
     @GetMapping("/dashboard/graficos")
     public String verGraficos(Model model) {

--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -383,3 +383,38 @@ h1, h2, h3 {
 .data-table tbody tr:hover {
     background-color: #f3f6fd;
 }
+
+/* ===== Sidebar Alert Section ===== */
+.sidebar .alertas-content {
+    max-height: 300px;
+    overflow-y: auto;
+    margin-top: 1rem;
+}
+
+.sidebar .sidebar-alert-form {
+    margin-top: 1rem;
+}
+
+.sidebar-alert-form select,
+.sidebar-alert-form input {
+    width: 100%;
+    padding: 6px;
+    margin-bottom: 0.5rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+}
+
+.sidebar-alert-form button {
+    width: 100%;
+    padding: 8px;
+    background-color: #3b82f6;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.sidebar-alert-form button:hover {
+    background-color: #2563eb;
+}

--- a/src/main/resources/static/css/station.css
+++ b/src/main/resources/static/css/station.css
@@ -1,0 +1,102 @@
+body {
+    margin: 0;
+    font-family: 'Segoe UI', sans-serif;
+    background-color: #f3f6fd;
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 220px;
+    background-color: #1e2a3a;
+    color: white;
+    min-height: 100vh;
+    padding: 1.5rem 1rem;
+}
+
+.sidebar h2 {
+    font-size: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.sidebar ul {
+    list-style: none;
+    padding: 0;
+}
+
+.sidebar li {
+    margin-bottom: 8px;
+}
+
+.sidebar a {
+    color: #e2e8f0;
+    text-decoration: none;
+    font-weight: 500;
+    display: block;
+    padding: 10px 15px;
+    border-radius: 8px;
+    transition: all 0.2s ease-in-out;
+}
+
+.sidebar a:hover {
+    color: white;
+    background-color: #2c3a4b;
+    text-decoration: none;
+}
+
+.sidebar a.active {
+    background-color: #3b82f6;
+    color: white;
+    font-weight: bold;
+}
+
+.main-content {
+    flex-grow: 1;
+    padding: 2rem;
+}
+
+.main-content h1 {
+    color: #2c3e50;
+    margin-bottom: 1.5rem;
+}
+
+.formulario {
+    background-color: white;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    max-width: 400px;
+}
+
+.formulario label {
+    font-weight: bold;
+    color: #34495e;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.formulario input[type="text"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    font-size: 1rem;
+    margin-bottom: 1rem;
+}
+
+.formulario button {
+    padding: 10px 20px;
+    font-weight: bold;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    margin-right: 10px;
+    transition: background-color 0.2s ease-in-out;
+    background-color: #3b82f6;
+    color: white;
+}
+
+.formulario .cancelar {
+    background-color: #e5e7eb;
+    color: #1e293b;
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -27,6 +27,19 @@
     </ul>
 
     <hr style="border: none; border-top: 1px solid #334155; margin: 20px 0;">
+    <h3>Alertas</h3>
+    <div id="alertas-container" class="alertas-content">
+        <p>Cargando alertas...</p>
+    </div>
+    <div id="alertas-pagination" class="pagination"></div>
+    <form id="alert-form" class="sidebar-alert-form">
+        <select id="alert-station-select"><option value="">Estación...</option></select>
+        <select id="alert-sensor-select" disabled><option value="">Sensor...</option></select>
+        <input type="number" id="alert-valor" placeholder="Umbral" required />
+        <input type="text" id="alert-mensaje" placeholder="Mensaje" required />
+        <button type="submit">Crear Alerta</button>
+    </form>
+    <hr style="border: none; border-top: 1px solid #334155; margin: 20px 0;">
 
     <ul>
         <li>
@@ -40,7 +53,7 @@
 <div class="main-content">
     <h1>Dashboard</h1>
 
-    <div id="resumen-general" class="cards-container"></div>
+    <div id="resumen-general" class="card-grid small-cards"></div>
 
     <h2 style="margin-top: 2rem;">Estaciones Meteorológicas</h2>
     <div id="summary" class="cards-container">
@@ -69,11 +82,6 @@
         </button>
     </div>
 
-    <h2 style="margin-top: 2rem;">📢 Alertas recientes</h2>
-    <div id="alertas-container">
-        <p>Cargando alertas...</p>
-    </div>
-    <div id="alertas-pagination" class="pagination"></div>
 </div>
 
 <script>
@@ -174,10 +182,10 @@ function cargarDashboard() {
         .then(data => {
             const container = document.getElementById("resumen-general");
             const html = `
-                <div class="card">Total Estaciones: ${data.total}</div>
-                <div class="card">En Línea: ${data.enLinea}</div>
-                <div class="card">Desconectadas: ${data.desconectadas}</div>
-                <div class="card alerta">Alarmas Activas: ${data.alertasActivas}</div>`;
+                <div class="info-card"><span>Total Estaciones</span><span>${data.total}</span></div>
+                <div class="info-card success"><span>En Línea</span><span>${data.enLinea}</span></div>
+                <div class="info-card warning"><span>Desconectadas</span><span>${data.desconectadas}</span></div>
+                <div class="info-card danger"><span>Alarmas Activas</span><span>${data.alertasActivas}</span></div>`;
             container.innerHTML = html;
         })
         .catch(() => {
@@ -202,6 +210,58 @@ function cargarDashboard() {
 }
 
 let stompClient = null;
+function cargarEstacionesForm() {
+    fetch('/api/stations')
+        .then(res => res.json())
+        .then(estaciones => {
+            const sel = document.getElementById('alert-station-select');
+            sel.innerHTML = '<option value="">Estaci\u00f3n...</option>';
+            estaciones.forEach(e => {
+                const opt = document.createElement('option');
+                opt.value = e.stationId;
+                opt.textContent = e.stationModel;
+                sel.appendChild(opt);
+            });
+        });
+}
+
+document.getElementById('alert-station-select').addEventListener('change', e => {
+    const id = e.target.value;
+    const sensorSel = document.getElementById('alert-sensor-select');
+    if (!id) {
+        sensorSel.disabled = true;
+        sensorSel.innerHTML = '<option value="">Sensor...</option>';
+        return;
+    }
+    fetch(`/api/stations/${id}/sensors`)
+        .then(res => res.json())
+        .then(sensores => {
+            sensorSel.innerHTML = '<option value="">Sensor...</option>';
+            sensores.forEach(s => {
+                const opt = document.createElement('option');
+                opt.value = s.sensorId;
+                opt.textContent = s.sensorModel;
+                sensorSel.appendChild(opt);
+            });
+            sensorSel.disabled = false;
+        });
+});
+
+document.getElementById('alert-form').addEventListener('submit', e => {
+    e.preventDefault();
+    const stationId = document.getElementById('alert-station-select').value;
+    const sensorId = document.getElementById('alert-sensor-select').value;
+    const valor = document.getElementById('alert-valor').value;
+    const mensaje = document.getElementById('alert-mensaje').value;
+    fetch('/api/alertas/manual', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: `stationId=${stationId}&sensorId=${sensorId}&umbral=${valor}&mensaje=${encodeURIComponent(mensaje)}`
+    }).then(() => {
+        document.getElementById('alert-mensaje').value = '';
+        document.getElementById('alert-valor').value = '';
+    });
+});
 
 function connectWs() {
     const socket = new SockJS('/ws');
@@ -237,6 +297,7 @@ document.addEventListener('visibilitychange', () => {
 window.onload = () => {
     cargarDashboard();
     connectWs();
+    cargarEstacionesForm();
 }
 
 </script>


### PR DESCRIPTION
## Summary
- show alert table and manual alert form in sidebar
- style edit page with new station.css
- display summary numbers in info cards
- add manual alert API endpoint

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6875b661bed88328b2aa52ed493213ec