### PR TITLE
Add success alerts after station actions

### DIFF
--- a/src/main/java/org/javadominicano/cmp/EstacionController.java
+++ b/src/main/java/org/javadominicano/cmp/EstacionController.java
@@ -269,7 +269,7 @@ public class EstacionController {
         dbManager.getOrCreateSensor(stationId, "Sensor_Precipitacion", "precipitacion", "mm");
         dbManager.getOrCreateSensor(stationId, "Sensor_HumedadSuelo", "humedad_suelo", "%");
 
-        return "redirect:/dashboard/administrar-estaciones";
+        return "redirect:/dashboard/administrar-estaciones?success=creado";
     }
 
 
@@ -285,14 +285,14 @@ public class EstacionController {
     @PreAuthorize("hasRole('ADMIN')")
     public String actualizarEstacion(@ModelAttribute StationModel estacion) {
         dbManager.updateStation(estacion);
-        return "redirect:/dashboard/administrar-estaciones";
+        return "redirect:/dashboard/administrar-estaciones?success=actualizado";
     }
 
     @PostMapping("/dashboard/estaciones/borrar/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public String borrarEstacion(@PathVariable int id) {
         dbManager.deleteStation(id);
-        return "redirect:/dashboard/administrar-estaciones";
+        return "redirect:/dashboard/administrar-estaciones?success=borrado";
     }
 
     @GetMapping("/dashboard/reportes")

--- a/src/main/resources/templates/stations.html
+++ b/src/main/resources/templates/stations.html
@@ -174,6 +174,33 @@
         const div = document.getElementById("sensorMenu-" + id);
         div.classList.toggle("hidden");
     }
+
+    // Mostrar alerta luego de las acciones de crear/actualizar/borrar
+    document.addEventListener('DOMContentLoaded', () => {
+        const params = new URLSearchParams(window.location.search);
+        const success = params.get('success');
+        if (success) {
+            let msg = '';
+            switch (success) {
+                case 'creado':
+                    msg = 'Estación creada correctamente';
+                    break;
+                case 'actualizado':
+                    msg = 'Estación actualizada correctamente';
+                    break;
+                case 'borrado':
+                    msg = 'Estación eliminada correctamente';
+                    break;
+            }
+            if (msg) {
+                alert(msg);
+            }
+            // Eliminar el parámetro para evitar mostrar la alerta al recargar
+            params.delete('success');
+            const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+            window.history.replaceState({}, '', newUrl);
+        }
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- notify user on create/update/delete station actions with a success query parameter
- display alert after redirect on stations page

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6876adfec5408328adac88d7ff926c55