### PR TITLE
Add alert rule handling

### DIFF
--- a/src/main/java/org/javadominicano/cmp/DatabaseManager.java
+++ b/src/main/java/org/javadominicano/cmp/DatabaseManager.java
@@ -3,6 +3,7 @@ package org.javadominicano.cmp;
 import org.javadominicano.cmp.model.StationModel;
 import org.javadominicano.cmp.model.SensorModel;
 import org.javadominicano.cmp.model.RecordModel;
+import org.javadominicano.cmp.model.AlertRuleModel;
 import org.javadominicano.cmp.dto.ReporteRecordDTO;
 import org.javadominicano.cmp.dto.AlertaDTO;
 
@@ -525,16 +526,71 @@ public void insertAlert(int stationId, int sensorId, double value, String messag
     }
 }
 
-public void toggleSensorActivo(int sensorId) {
-    String sql = "UPDATE Sensor SET activo = NOT activo WHERE sensor_id = ?";
-    try (Connection conn = getConnection();
-         PreparedStatement stmt = conn.prepareStatement(sql)) {
-        stmt.setInt(1, sensorId);
-        stmt.executeUpdate();
-    } catch (SQLException e) {
-        e.printStackTrace();
+    public void toggleSensorActivo(int sensorId) {
+        String sql = "UPDATE Sensor SET activo = NOT activo WHERE sensor_id = ?";
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, sensorId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
-}
+
+    // ==== Alert Rule management ====
+
+    public void insertAlertRule(int stationId, int sensorId, String tipo, double umbral) {
+        String sql = "INSERT INTO AlertRule (station_id, sensor_id, tipo, umbral, activa) VALUES (?, ?, ?, ?, 0)";
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, stationId);
+            stmt.setInt(2, sensorId);
+            stmt.setString(3, tipo);
+            stmt.setDouble(4, umbral);
+            stmt.executeUpdate();
+            System.out.printf("📝 Regla de alerta creada: %s %.2f (%d-%d)\n", tipo, umbral, stationId, sensorId);
+        } catch (SQLException e) {
+            System.out.println("❌ Error insertando regla de alerta:");
+            e.printStackTrace();
+        }
+    }
+
+    public List<AlertRuleModel> getAlertRulesBySensor(int stationId, int sensorId) {
+        List<AlertRuleModel> reglas = new ArrayList<>();
+        String sql = "SELECT * FROM AlertRule WHERE station_id = ? AND sensor_id = ?";
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, stationId);
+            stmt.setInt(2, sensorId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    AlertRuleModel r = new AlertRuleModel();
+                    r.setRuleId(rs.getInt("rule_id"));
+                    r.setStationId(rs.getInt("station_id"));
+                    r.setSensorId(rs.getInt("sensor_id"));
+                    r.setTipo(rs.getString("tipo"));
+                    r.setUmbral(rs.getDouble("umbral"));
+                    r.setActiva(rs.getBoolean("activa"));
+                    reglas.add(r);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return reglas;
+    }
+
+    public void updateAlertRuleState(int ruleId, boolean activa) {
+        String sql = "UPDATE AlertRule SET activa = ? WHERE rule_id = ?";
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setBoolean(1, activa);
+            stmt.setInt(2, ruleId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
 
 
 

--- a/src/main/java/org/javadominicano/cmp/EstacionController.java
+++ b/src/main/java/org/javadominicano/cmp/EstacionController.java
@@ -465,8 +465,19 @@ public class EstacionController {
     }
     @PostMapping("/api/alertas/manual")
     @ResponseBody
-    public void crearAlertaManual(@RequestParam int stationId, @RequestParam int sensorId, @RequestParam double umbral, @RequestParam String mensaje) {
-        dbManager.insertAlert(stationId, sensorId, umbral, mensaje);
+    public void crearAlertaManual(@RequestParam int stationId,
+                                  @RequestParam int sensorId,
+                                  @RequestParam double umbral,
+                                  @RequestParam String mensaje) {
+        // "mensaje" contiene el tipo: ALTA o BAJA
+        dbManager.insertAlertRule(stationId, sensorId, mensaje, umbral);
+    }
+
+    @GetMapping("/dashboard/alertas")
+    public String verAlertas(Model model) {
+        List<StationModel> estaciones = dbManager.getStations();
+        model.addAttribute("estaciones", estaciones);
+        return "alertas";
     }
 
 

--- a/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
+++ b/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
@@ -97,32 +97,24 @@ public class SuscriptorCallback implements MqttCallback {
             System.out.printf("✅ Registro físico insertado: estación=%s, sensor=%s, valor=%.2f\n",
                     stationModel, sensorModel, valor);
 
-            // 🔔 Evaluar alertas
-            String mensajeAlerta = null;
-            switch (sensorType.toLowerCase()) {
-                case "temperatura":
-                    if (valor > 40) mensajeAlerta = "Temperatura excesiva";
-                    break;
-                case "humedad":
-                    if (valor > 90) mensajeAlerta = "Humedad alta";
-                    break;
-                case "presion":
-                    if (valor < 950 || valor > 1050) mensajeAlerta = "Presión fuera de rango";
-                    break;
-                case "viento":
-                    if (valor > 25) mensajeAlerta = "Viento peligroso";
-                    break;
-                case "precipitacion":
-                    if (valor > 50) mensajeAlerta = "Precipitación intensa";
-                    break;
-                case "humedad_suelo":
-                    if (valor > 80) mensajeAlerta = "Humedad del suelo elevada";
-                    break;
-            }
+            // 🔔 Evaluar reglas de alerta configuradas
+            dbFisico.getAlertRulesBySensor(stationId, sensorId).forEach(regla -> {
+                boolean cumple;
+                if ("ALTA".equalsIgnoreCase(regla.getTipo())) {
+                    cumple = valor >= regla.getUmbral();
+                } else {
+                    cumple = valor <= regla.getUmbral();
+                }
 
-            if (mensajeAlerta != null) {
-                dbFisico.insertAlert(stationId, sensorId, valor, mensajeAlerta);
-            }
+                if (cumple && !regla.isActiva()) {
+                    String msg = "ALTA".equalsIgnoreCase(regla.getTipo())
+                            ? "Umbral alto superado" : "Umbral bajo alcanzado";
+                    dbFisico.insertAlert(stationId, sensorId, valor, msg);
+                    dbFisico.updateAlertRuleState(regla.getRuleId(), true);
+                } else if (!cumple && regla.isActiva()) {
+                    dbFisico.updateAlertRuleState(regla.getRuleId(), false);
+                }
+            });
 
         } catch (Exception e) {
             System.out.println("❌ Error al procesar mensaje físico:");

--- a/src/main/java/org/javadominicano/cmp/model/AlertRuleModel.java
+++ b/src/main/java/org/javadominicano/cmp/model/AlertRuleModel.java
@@ -1,0 +1,28 @@
+package org.javadominicano.cmp.model;
+
+public class AlertRuleModel {
+    private int ruleId;
+    private int stationId;
+    private int sensorId;
+    private String tipo; // ALTA o BAJA
+    private double umbral;
+    private boolean activa; // true si la condicion esta activa actualmente
+
+    public int getRuleId() { return ruleId; }
+    public void setRuleId(int ruleId) { this.ruleId = ruleId; }
+
+    public int getStationId() { return stationId; }
+    public void setStationId(int stationId) { this.stationId = stationId; }
+
+    public int getSensorId() { return sensorId; }
+    public void setSensorId(int sensorId) { this.sensorId = sensorId; }
+
+    public String getTipo() { return tipo; }
+    public void setTipo(String tipo) { this.tipo = tipo; }
+
+    public double getUmbral() { return umbral; }
+    public void setUmbral(double umbral) { this.umbral = umbral; }
+
+    public boolean isActiva() { return activa; }
+    public void setActiva(boolean activa) { this.activa = activa; }
+}

--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -384,14 +384,48 @@ h1, h2, h3 {
     background-color: #f3f6fd;
 }
 
-
 /* ===== Alert Section ===== */
 .alert-form {
     margin-top: 1rem;
+    background-color: #ffffff;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    max-width: 500px;
+}
+
+.alert-form label {
+    font-weight: bold;
+    color: #334155;
+    display: block;
+    margin-top: 0.5rem;
 }
 
 .alert-form select,
 .alert-form input {
+    width: 100%;
+    padding: 8px 12px;
+    margin-top: 0.25rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    font-size: 0.95rem;
+}
+
+.alert-form button {
+    margin-top: 1rem;
+    padding: 10px 20px;
+    background-color: #3b82f6;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.alert-form button:hover {
+    background-color: #2563eb;
+}
 
 /* ===== Sidebar Alert Section ===== */
 .sidebar .alertas-content {
@@ -406,7 +440,6 @@ h1, h2, h3 {
 
 .sidebar-alert-form select,
 .sidebar-alert-form input {
-
     width: 100%;
     padding: 6px;
     margin-bottom: 0.5rem;
@@ -414,11 +447,7 @@ h1, h2, h3 {
     border-radius: 4px;
 }
 
-.alert-form button {
-
-
 .sidebar-alert-form button {
-
     width: 100%;
     padding: 8px;
     background-color: #3b82f6;
@@ -429,10 +458,6 @@ h1, h2, h3 {
     cursor: pointer;
 }
 
-.alert-form button:hover {
-
-
 .sidebar-alert-form button:hover {
-
     background-color: #2563eb;
 }

--- a/src/main/resources/templates/alertas.html
+++ b/src/main/resources/templates/alertas.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <title>Alertas | WeatherNet</title>
+    <link rel="stylesheet" href="/css/dashboard.css">
+</head>
+<body>
+<div class="sidebar">
+    <h2>WeatherNet</h2>
+    <ul>
+        <li><a href="/dashboard">Dashboard</a></li>
+        <li sec:authorize="hasRole('ADMIN')"><a href="/dashboard/administrar-estaciones">Estaciones</a></li>
+        <li><a href="/dashboard/reportes">Reportes</a></li>
+        <li><a href="/dashboard/graficos">Gráficos</a></li>
+        <li><a href="/dashboard/alertas" class="active">Alertas</a></li>
+    </ul>
+    <hr style="border: none; border-top: 1px solid #334155; margin: 20px 0;">
+    <ul>
+        <li>
+            <form th:action="@{/logout}" method="post">
+                <button type="submit" style="background: none; border: none; color: #f87171; font-weight: bold; cursor: pointer;">⏻ Cerrar sesión</button>
+            </form>
+        </li>
+    </ul>
+</div>
+
+<div class="main-content">
+    <h1>Gestión de Alertas</h1>
+
+    <div class="alert-form">
+        <h3>Crear Alerta</h3>
+        <form id="alertForm">
+            <label for="estacionSelect">Estación</label>
+            <select id="estacionSelect" required>
+                <option value="">Seleccione</option>
+            </select>
+            <label for="sensorSelect">Sensor</label>
+            <select id="sensorSelect" required disabled>
+                <option value="">Seleccione una estación</option>
+            </select>
+            <label for="tipoSelect">Tipo de alerta</label>
+            <select id="tipoSelect">
+                <option value="ALTA">Alta</option>
+                <option value="BAJA">Baja</option>
+            </select>
+            <label for="umbralInput">Umbral</label>
+            <input type="number" step="0.1" id="umbralInput" required>
+            <button type="submit">Guardar Alerta</button>
+        </form>
+    </div>
+
+    <div class="alertas-content">
+        <h3>Alertas Existentes</h3>
+        <div class="filters" style="margin-bottom:1rem; display:flex; gap:1rem; flex-wrap:wrap;">
+            <select id="filtroEstacion">
+                <option value="">Todas las estaciones</option>
+            </select>
+            <select id="filtroTipo">
+                <option value="">Todos los tipos</option>
+                <option value="ALTA">Alta</option>
+                <option value="BAJA">Baja</option>
+            </select>
+        </div>
+        <table class="alert-table" id="alertTable">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Estación</th>
+                <th>Sensor</th>
+                <th>Tipo</th>
+                <th>Umbral</th>
+                <th>Fecha</th>
+                <th>Estado</th>
+            </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+        <div class="pagination" id="alertPagination"></div>
+    </div>
+</div>
+
+<script>
+const estaciones = [];
+let alertas = [];
+let currentPage = 1;
+const rowsPerPage = 5;
+
+function cargarEstaciones() {
+    fetch('/api/stations')
+        .then(r => r.json())
+        .then(data => {
+            data.forEach(e => {
+                estaciones.push(e);
+                const opt = document.createElement('option');
+                opt.value = e.stationId;
+                opt.textContent = e.stationModel;
+                document.getElementById('estacionSelect').appendChild(opt.cloneNode(true));
+                document.getElementById('filtroEstacion').appendChild(opt);
+            });
+        });
+}
+
+function cargarSensores(estacionId) {
+    const sensorSelect = document.getElementById('sensorSelect');
+    sensorSelect.innerHTML = '<option value="">Seleccione un sensor</option>';
+    sensorSelect.disabled = true;
+    if(!estacionId) return;
+    fetch(`/api/stations/${estacionId}/sensors`)
+        .then(r => r.json())
+        .then(data => {
+            data.forEach(s => {
+                const opt = document.createElement('option');
+                opt.value = s.sensorId;
+                opt.textContent = `${s.sensorModel} (${s.sensorType})`;
+                sensorSelect.appendChild(opt);
+            });
+            sensorSelect.disabled = false;
+        });
+}
+
+function cargarAlertas() {
+    fetch('/api/alertas')
+        .then(r => r.json())
+        .then(data => {
+            alertas = data.map((a, idx) => ({
+                id: idx + 1,
+                estacion: a.nombreEstacion,
+                sensor: a.sensorNombre,
+                tipo: a.mensaje && a.mensaje.toLowerCase().includes('baja') ? 'BAJA' : 'ALTA',
+                umbral: a.valor,
+                fecha: new Date(a.fecha).toLocaleString(),
+                estado: 'Activo'
+            }));
+            aplicarFiltros();
+        });
+}
+
+function renderTabla(datos) {
+    const tbody = document.querySelector('#alertTable tbody');
+    tbody.innerHTML = '';
+    const start = (currentPage-1)*rowsPerPage;
+    const pageData = datos.slice(start, start+rowsPerPage);
+    pageData.forEach(a => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${a.id}</td><td>${a.estacion}</td><td>${a.sensor}</td><td>${a.tipo}</td><td>${a.umbral}</td><td>${a.fecha}</td><td>${a.estado}</td>`;
+        tbody.appendChild(tr);
+    });
+    renderPaginacion(datos.length);
+}
+
+function renderPaginacion(total) {
+    const pag = document.getElementById('alertPagination');
+    pag.innerHTML = '';
+    const pages = Math.ceil(total/rowsPerPage);
+    for(let i=1;i<=pages;i++) {
+        const btn = document.createElement('button');
+        btn.textContent = i;
+        btn.disabled = i===currentPage;
+        btn.addEventListener('click',()=>{currentPage=i;aplicarFiltros();});
+        pag.appendChild(btn);
+    }
+}
+
+function aplicarFiltros() {
+    let datos = alertas.slice();
+    const est = document.getElementById('filtroEstacion').value;
+    const tipo = document.getElementById('filtroTipo').value;
+    if(est) datos = datos.filter(a => a.estacion === estaciones.find(e => e.stationId==est).stationModel);
+    if(tipo) datos = datos.filter(a => a.tipo === tipo);
+    renderTabla(datos);
+}
+
+document.getElementById('estacionSelect').addEventListener('change', e => cargarSensores(e.target.value));
+document.getElementById('filtroEstacion').addEventListener('change', ()=>{currentPage=1;aplicarFiltros();});
+document.getElementById('filtroTipo').addEventListener('change', ()=>{currentPage=1;aplicarFiltros();});
+
+document.getElementById('alertForm').addEventListener('submit', e => {
+    e.preventDefault();
+    const payload = new URLSearchParams();
+    payload.append('stationId', document.getElementById('estacionSelect').value);
+    payload.append('sensorId', document.getElementById('sensorSelect').value);
+    payload.append('umbral', document.getElementById('umbralInput').value);
+    payload.append('mensaje', document.getElementById('tipoSelect').value);
+    fetch('/api/alertas/manual', {
+        method:'POST',
+        body: payload
+    }).then(()=>{
+        e.target.reset();
+        document.getElementById('sensorSelect').disabled=true;
+        cargarAlertas();
+    });
+});
+
+cargarEstaciones();
+cargarAlertas();
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -27,7 +27,7 @@
     <hr style="border: none; border-top: 1px solid #334155; margin: 20px 0;">
 
     <ul>
-        <li><a href="#alertas-section">Alertas</a></li>
+        <li><a href="/dashboard/alertas">Alertas</a></li>
     </ul>
 
     <hr style="border: none; border-top: 1px solid #334155; margin: 20px 0;">

--- a/src/main/resources/templates/editar-estacion.html
+++ b/src/main/resources/templates/editar-estacion.html
@@ -14,6 +14,7 @@
         <li><a href="/dashboard/administrar-estaciones" class="active">Estaciones</a></li>
         <li><a href="/dashboard/reportes">Reportes</a></li>
         <li><a href="/dashboard/graficos">Gráficos</a></li>
+        <li><a href="/dashboard/alertas">Alertas</a></li>
     </ul>
 </div>
 

--- a/src/main/resources/templates/graficos.html
+++ b/src/main/resources/templates/graficos.html
@@ -17,6 +17,7 @@
         <li sec:authorize="hasRole('ADMIN')"><a href="/dashboard/administrar-estaciones">Estaciones</a></li>
         <li><a href="/dashboard/reportes">Reportes</a></li>
         <li><a href="/dashboard/graficos" class="active">Gráficos</a></li>
+        <li><a href="/dashboard/alertas">Alertas</a></li>
     </ul>
 </div>
 

--- a/src/main/resources/templates/reportes.html
+++ b/src/main/resources/templates/reportes.html
@@ -24,6 +24,7 @@
         <li sec:authorize="hasRole('ADMIN')"><a href="/dashboard/administrar-estaciones">Estaciones</a></li>
         <li><a href="/dashboard/reportes" class="active">Reportes</a></li>
         <li><a href="/dashboard/graficos">Gráficos</a></li>
+        <li><a href="/dashboard/alertas">Alertas</a></li>
     </ul>
     <hr style="border: none; border-top: 1px solid #334155; margin: 20px 0;">
     <ul>

--- a/src/main/resources/templates/stations.html
+++ b/src/main/resources/templates/stations.html
@@ -62,6 +62,7 @@
         <li><a href="/dashboard/administrar-estaciones" class="active">Estaciones</a></li>
         <li><a href="/dashboard/reportes">Reportes</a></li>
         <li><a href="/dashboard/graficos">Gráficos</a></li>
+        <li><a href="/dashboard/alertas">Alertas</a></li>
     </ul>
 </div>
 


### PR DESCRIPTION
## Summary
- create `AlertRuleModel` to represent alert rules
- store and update alert rule state in `DatabaseManager`
- replace static alert checks with rule-based evaluation
- save alert rules through `/api/alertas/manual`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687795d7c3d88328a698ede547a16ad4