### PR TITLE
Add wind direction and disconnect alerts

### DIFF
--- a/src/main/java/org/javadominicano/cmp/DatabaseManager.java
+++ b/src/main/java/org/javadominicano/cmp/DatabaseManager.java
@@ -430,7 +430,8 @@ public List<AlertaDTO> getAlertasActivas() {
     List<AlertaDTO> alertas = new ArrayList<>();
 
     String sql = """
-        SELECT 
+        SELECT
+            wa.alert_id AS id,
             wa.alert_datetime AS fecha,
             s.station_model AS nombreEstacion,
             se.sensor_model AS sensorNombre,
@@ -438,7 +439,7 @@ public List<AlertaDTO> getAlertasActivas() {
             wa.value AS valor,
             wa.message AS mensaje
         FROM WeatherAlert wa
-        JOIN Sensor se ON wa.sensor_id = se.sensor_id
+        LEFT JOIN Sensor se ON wa.sensor_id = se.sensor_id
         JOIN Station s ON wa.station_id = s.station_id
         ORDER BY wa.alert_datetime DESC
         LIMIT 20
@@ -450,6 +451,7 @@ public List<AlertaDTO> getAlertasActivas() {
 
         while (rs.next()) {
             AlertaDTO alerta = new AlertaDTO();
+            alerta.setId(rs.getInt("id"));
             alerta.setFecha(rs.getTimestamp("fecha"));
             alerta.setNombreEstacion(rs.getString("nombreEstacion"));
             alerta.setSensorNombre(rs.getString("sensorNombre"));
@@ -547,6 +549,34 @@ public void insertAlert(int stationId, int sensorId, double value, String messag
         System.out.println("❌ Error insertando alerta:");
         e.printStackTrace();
     }
+}
+
+public void deleteAlerta(int alertaId) {
+    String sql = "DELETE FROM WeatherAlert WHERE alert_id = ?";
+    try (Connection conn = getConnection();
+         PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setInt(1, alertaId);
+        stmt.executeUpdate();
+    } catch (SQLException e) {
+        e.printStackTrace();
+    }
+}
+
+public boolean hasDisconnectAlert(int stationId) {
+    String sql = "SELECT COUNT(*) FROM WeatherAlert WHERE station_id = ? AND sensor_id = 0 AND message = ?";
+    try (Connection conn = getConnection();
+         PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setInt(1, stationId);
+        stmt.setString(2, "Estación desconectada por inactividad");
+        try (ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                return rs.getInt(1) > 0;
+            }
+        }
+    } catch (SQLException e) {
+        e.printStackTrace();
+    }
+    return false;
 }
 
     public void toggleSensorActivo(int sensorId) {

--- a/src/main/java/org/javadominicano/cmp/EstacionController.java
+++ b/src/main/java/org/javadominicano/cmp/EstacionController.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -101,6 +102,9 @@ public class EstacionController {
                             break;
                         case "viento":
                             data.put("viento", valor);
+                            break;
+                        case "direccion_viento":
+                            data.put("direccion_viento", valor);
                             break;
                         case "precipitacion":
                         case "precipitación":
@@ -575,6 +579,12 @@ public class EstacionController {
     @ResponseBody
     public List<AlertaDTO> obtenerAlertas() {
         return dbManager.getAlertasActivas();
+    }
+
+    @DeleteMapping("/alertas/{id}")
+    public ResponseEntity<Void> eliminarAlerta(@PathVariable int id) {
+        dbManager.deleteAlerta(id);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/dashboard/sensor/{id}/toggle")

--- a/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
+++ b/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
@@ -48,32 +48,43 @@ public class SuscriptorCallback implements MqttCallback {
 
     private void procesarMensajeFisico(String topic, MqttMessage message) {
         try {
-            double valor = Double.parseDouble(message.toString());
+            double valor;
             Date fecha = new Date();
 
             String sensorType, unit, sensorModel;
 
-            if (topic.endsWith("/temperatura")) {
+            if (topic.endsWith("/direccion_viento")) {
+                sensorType = "direccion_viento";
+                unit = "";
+                sensorModel = "Sensor_DirViento";
+                valor = convertirDireccionAFloat(message.toString());
+            } else if (topic.endsWith("/temperatura")) {
+                valor = Double.parseDouble(message.toString());
                 sensorType = "temperatura";
                 unit = "°C";
                 sensorModel = "Sensor_Temp";
             } else if (topic.endsWith("/humedad")) {
+                valor = Double.parseDouble(message.toString());
                 sensorType = "humedad";
                 unit = "%";
                 sensorModel = "Sensor_Hum";
             } else if (topic.endsWith("/presion") || topic.endsWith("/presión")) {
+                valor = Double.parseDouble(message.toString());
                 sensorType = "presion";
                 unit = "hPa";
                 sensorModel = "Sensor_Pres";
             } else if (topic.endsWith("/viento")) {
+                valor = Double.parseDouble(message.toString());
                 sensorType = "viento";
                 unit = "m/s";
                 sensorModel = "Sensor_Viento";
             } else if (topic.endsWith("/precipitacion") || topic.endsWith("/precipitación")) {
+                valor = Double.parseDouble(message.toString());
                 sensorType = "precipitacion";
                 unit = "mm";
                 sensorModel = "Sensor_Prec";
             } else if (topic.endsWith("/Humedad_suelo")) {
+                valor = Double.parseDouble(message.toString());
                 sensorType = "humedad_suelo";
                 unit = "%";
                 sensorModel = "Sensor_HumedadSuelo";
@@ -162,6 +173,7 @@ public class SuscriptorCallback implements MqttCallback {
                     case "humedad" -> data.put("humedad", val);
                     case "presion" -> data.put("presion", val);
                     case "viento" -> data.put("viento", val);
+                    case "direccion_viento" -> data.put("direccion_viento", val);
                     case "precipitacion" -> data.put("precipitacion", val);
                     case "humedad_suelo" -> data.put("humedad_suelo", val);
                 }
@@ -191,6 +203,20 @@ public class SuscriptorCallback implements MqttCallback {
         alerta.setMensaje(mensaje);
 
         return alerta;
+    }
+
+    private double convertirDireccionAFloat(String direccion) {
+        return switch (direccion.trim().toUpperCase()) {
+            case "N" -> 0.0;
+            case "NE" -> 45.0;
+            case "E" -> 90.0;
+            case "SE" -> 135.0;
+            case "S" -> 180.0;
+            case "SW", "SO" -> 225.0;
+            case "W", "O" -> 270.0;
+            case "NW", "NO" -> 315.0;
+            default -> -1.0;
+        };
     }
 
     @Override

--- a/src/main/java/org/javadominicano/cmp/config/StationMonitor.java
+++ b/src/main/java/org/javadominicano/cmp/config/StationMonitor.java
@@ -1,0 +1,53 @@
+package org.javadominicano.cmp.config;
+
+import org.javadominicano.cmp.DatabaseManager;
+import org.javadominicano.cmp.dto.AlertaDTO;
+import org.javadominicano.cmp.model.StationModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class StationMonitor {
+    private final DatabaseManager db = new DatabaseManager(
+            "jdbc:mysql://192.168.100.168/MqttBase",
+            "usermqtt",
+            "Mqtt1234!"
+    );
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Autowired
+    public StationMonitor(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @Scheduled(fixedDelay = 5000)
+    public void checkStations() {
+        List<StationModel> estaciones = db.getStations();
+        Date now = new Date();
+        for (StationModel est : estaciones) {
+            Date last = db.getLastRecordTimeByStation(est.getStationId());
+            if (last == null || now.getTime() - last.getTime() > 10000) {
+                if (!db.hasDisconnectAlert(est.getStationId())) {
+                    db.insertAlert(est.getStationId(), 0, 0.0,
+                            "Estación desconectada por inactividad");
+
+                    AlertaDTO alerta = new AlertaDTO();
+                    alerta.setId(0);
+                    alerta.setFecha(new Date());
+                    alerta.setNombreEstacion(est.getStationModel());
+                    alerta.setSensorNombre("N/A");
+                    alerta.setTipoSensor("N/A");
+                    alerta.setValor(0.0);
+                    alerta.setMensaje("Estación desconectada por inactividad");
+
+                    messagingTemplate.convertAndSend("/topic/alertas", alerta);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/javadominicano/cmp/dto/AlertaDTO.java
+++ b/src/main/java/org/javadominicano/cmp/dto/AlertaDTO.java
@@ -3,6 +3,7 @@ package org.javadominicano.cmp.dto;
 import java.util.Date;
 
 public class AlertaDTO {
+    private int id;
     private Date fecha;
     private String nombreEstacion;
     private String sensorNombre;
@@ -11,6 +12,8 @@ public class AlertaDTO {
     private String mensaje;
 
     // Getters y Setters
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
     public Date getFecha() { return fecha; }
     public void setFecha(Date fecha) { this.fecha = fecha; }
 

--- a/src/main/resources/templates/alertas.html
+++ b/src/main/resources/templates/alertas.html
@@ -72,6 +72,7 @@
                 <th>Umbral</th>
                 <th>Fecha</th>
                 <th>Estado</th>
+                <th sec:authorize="hasRole('ADMIN')">Acciones</th>
             </tr>
             </thead>
             <tbody>
@@ -83,6 +84,9 @@
 
 <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1.5.1/dist/sockjs.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+<script th:inline="javascript">
+    const isAdmin = [[${#authorization.expression('hasRole(''ADMIN'')')}]];
+</script>
 
 <script>
 const estaciones = [];
@@ -129,10 +133,10 @@ function cargarAlertas() {
     fetch('/api/alertas')
         .then(r => r.json())
         .then(data => {
-            alertas = data.map((a, idx) => ({
-                id: idx + 1,
+            alertas = data.map(a => ({
+                id: a.id,
                 estacion: a.nombreEstacion,
-                sensor: a.sensorNombre,
+                sensor: a.sensorNombre || 'N/A',
                 tipo: a.mensaje && a.mensaje.toLowerCase().includes('baja') ? 'BAJA' : 'ALTA',
                 umbral: a.valor,
                 fecha: new Date(a.fecha).toLocaleString(),
@@ -147,18 +151,8 @@ function conectarWS() {
     const socket = new SockJS('/ws');
     stompClient = Stomp.over(socket);
     stompClient.connect({}, () => {
-        stompClient.subscribe('/topic/alertas', msg => {
-            const a = JSON.parse(msg.body);
-            alertas.unshift({
-                id: alertas.length + 1,
-                estacion: a.nombreEstacion,
-                sensor: a.sensorNombre,
-                tipo: a.mensaje && a.mensaje.toLowerCase().includes('baja') ? 'BAJA' : 'ALTA',
-                umbral: a.valor,
-                fecha: new Date(a.fecha).toLocaleString(),
-                estado: 'Activo'
-            });
-            aplicarFiltros();
+        stompClient.subscribe('/topic/alertas', () => {
+            cargarAlertas();
         });
     });
 }
@@ -171,6 +165,11 @@ function renderTabla(datos) {
     pageData.forEach(a => {
         const tr = document.createElement('tr');
         tr.innerHTML = `<td>${a.id}</td><td>${a.estacion}</td><td>${a.sensor}</td><td>${a.tipo}</td><td>${a.umbral}</td><td>${a.fecha}</td><td>${a.estado}</td>`;
+        if(isAdmin) {
+            const td = document.createElement('td');
+            td.innerHTML = `<button class="btn btn-danger btn-sm" onclick="eliminarAlerta(${a.id})">Eliminar</button>`;
+            tr.appendChild(td);
+        }
         tbody.appendChild(tr);
     });
     renderPaginacion(datos.length);
@@ -187,6 +186,16 @@ function renderPaginacion(total) {
         btn.addEventListener('click',()=>{currentPage=i;aplicarFiltros();});
         pag.appendChild(btn);
     }
+}
+
+function eliminarAlerta(id) {
+  fetch(`/alertas/${id}`, { method: 'DELETE' })
+    .then(res => {
+      if(res.ok) {
+        alert('✅ Alerta eliminada');
+        cargarAlertas();
+      }
+    });
 }
 
 function aplicarFiltros() {

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Dashboard | WeatherNet</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/dashboard.css" />
 </head>
 <body>
@@ -43,6 +44,7 @@
 
 <div class="main-content">
     <h1>Dashboard</h1>
+    <div id="alert-banner"></div>
 
     <!-- 🧾 Resumen de estado general -->
     <div id="resumen-general" class="indicator-container"></div>
@@ -66,6 +68,19 @@
 let estacionesData = {};
 let alertCount = 0;
 let stompClient;
+
+function mostrarBanner(nombre) {
+    const cont = document.getElementById('alert-banner');
+    cont.innerHTML = `
+    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+      ⚠️ La estación <strong>${nombre}</strong> se ha desconectado.
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>`;
+}
+
+function ocultarBanner() {
+    document.getElementById('alert-banner').innerHTML = '';
+}
 
 function cargarDashboard() {
     // Cargar resumen general
@@ -170,6 +185,7 @@ function actualizarResumenGeneral() {
 
 function actualizarUIEstacion(dto) {
     estacionesData[dto.stationName] = dto;
+    if(dto.status === 'EN_LINEA') ocultarBanner();
     let card = document.getElementById(`station-${dto.stationName}`);
     if (!card) {
         card = document.createElement('div');
@@ -203,9 +219,12 @@ function conectarWS() {
             actualizarUIEstacion(data);
         });
         stompClient.subscribe('/topic/alertas', msg => {
+            const a = JSON.parse(msg.body);
             alertCount++;
             actualizarResumenGeneral();
-            console.log('Alerta recibida', JSON.parse(msg.body));
+            if(a.mensaje === 'Estación desconectada por inactividad') {
+                mostrarBanner(a.nombreEstacion);
+            }
         });
     });
 }


### PR DESCRIPTION
## Summary
- support `direccion_viento` topic and parse compass values
- expose alert deletion endpoint and DB helper
- include disconnect-alert scheduler to create alerts when stations stop reporting
- show deletion button for admins in alert table
- display banner on dashboard when a station disconnects
- adapt DTOs and queries for alert ID handling

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6882893310a08328a2150d793fce25e6