### PR TITLE
Fix duplicate disconnection alerts

### DIFF
--- a/src/main/java/org/javadominicano/cmp/DatabaseManager.java
+++ b/src/main/java/org/javadominicano/cmp/DatabaseManager.java
@@ -127,6 +127,29 @@ public class DatabaseManager {
         return null;
     }
 
+    public SensorModel getSensorById(int sensorId) {
+        String query = "SELECT * FROM Sensor WHERE sensor_id = ?";
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(query)) {
+            stmt.setInt(1, sensorId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    SensorModel s = new SensorModel();
+                    s.setSensorId(rs.getInt("sensor_id"));
+                    s.setStationId(rs.getInt("station_id"));
+                    s.setSensorModel(rs.getString("sensor_model"));
+                    s.setSensorType(rs.getString("sensor_type"));
+                    s.setUnit(rs.getString("unit"));
+                    s.setActivo(rs.getBoolean("activo"));
+                    return s;
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
     public int getOrCreateStation(String stationModel) {
     try (Connection conn = getConnection()) {
         // Buscar estación existente

--- a/src/main/java/org/javadominicano/cmp/config/AlertRuleChecker.java
+++ b/src/main/java/org/javadominicano/cmp/config/AlertRuleChecker.java
@@ -3,6 +3,11 @@ package org.javadominicano.cmp.config;
 import org.javadominicano.cmp.DatabaseManager;
 import org.javadominicano.cmp.model.AlertRuleModel;
 import org.javadominicano.cmp.model.RecordModel;
+import org.javadominicano.cmp.model.SensorModel;
+import org.javadominicano.cmp.model.StationModel;
+import org.javadominicano.cmp.dto.AlertaDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +20,12 @@ public class AlertRuleChecker {
             "usermqtt",
             "Mqtt1234!"
     );
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Autowired
+    public AlertRuleChecker(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
 
     @Scheduled(fixedDelay = 60000)
     public void checkRules() {
@@ -26,9 +37,22 @@ public class AlertRuleChecker {
                     ? last.getValue() >= r.getUmbral()
                     : last.getValue() <= r.getUmbral();
             if (cumple && !r.isActiva()) {
-                db.insertAlert(r.getStationId(), r.getSensorId(), last.getValue(),
-                        "Umbral " + r.getTipo().toLowerCase());
+                String msg = "ALTA".equalsIgnoreCase(r.getTipo())
+                        ? "Umbral alto superado" : "Umbral bajo alcanzado";
+                db.insertAlert(r.getStationId(), r.getSensorId(), last.getValue(), msg);
                 db.updateAlertRuleState(r.getRuleId(), true);
+
+                StationModel st = db.getStationById(r.getStationId());
+                SensorModel se = db.getSensorById(r.getSensorId());
+                AlertaDTO alerta = new AlertaDTO();
+                alerta.setId(0);
+                alerta.setFecha(new java.util.Date());
+                alerta.setNombreEstacion(st != null ? st.getStationModel() : String.valueOf(r.getStationId()));
+                alerta.setSensorNombre(se != null ? se.getSensorModel() : String.valueOf(r.getSensorId()));
+                alerta.setTipoSensor(se != null ? se.getSensorType() : "");
+                alerta.setValor(last.getValue());
+                alerta.setMensaje(msg);
+                messagingTemplate.convertAndSend("/topic/alertas", alerta);
             } else if (!cumple && r.isActiva()) {
                 db.updateAlertRuleState(r.getRuleId(), false);
             }

--- a/src/main/java/org/javadominicano/cmp/config/StationMonitor.java
+++ b/src/main/java/org/javadominicano/cmp/config/StationMonitor.java
@@ -9,7 +9,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class StationMonitor {
@@ -19,6 +21,7 @@ public class StationMonitor {
             "Mqtt1234!"
     );
     private final SimpMessagingTemplate messagingTemplate;
+    private final Set<Integer> offlineStations = new HashSet<>();
 
     @Autowired
     public StationMonitor(SimpMessagingTemplate messagingTemplate) {
@@ -31,22 +34,29 @@ public class StationMonitor {
         Date now = new Date();
         for (StationModel est : estaciones) {
             Date last = db.getLastRecordTimeByStation(est.getStationId());
-            if (last == null || now.getTime() - last.getTime() > 10000) {
-                if (!db.hasDisconnectAlert(est.getStationId())) {
-                    db.insertAlert(est.getStationId(), 0, 0.0,
-                            "Estación desconectada por inactividad");
+            boolean desconectada = (last == null || now.getTime() - last.getTime() > 10000);
 
-                    AlertaDTO alerta = new AlertaDTO();
-                    alerta.setId(0);
-                    alerta.setFecha(new Date());
-                    alerta.setNombreEstacion(est.getStationModel());
-                    alerta.setSensorNombre("N/A");
-                    alerta.setTipoSensor("N/A");
-                    alerta.setValor(0.0);
-                    alerta.setMensaje("Estación desconectada por inactividad");
+            if (desconectada) {
+                if (!offlineStations.contains(est.getStationId())) {
+                    offlineStations.add(est.getStationId());
+                    if (!db.hasDisconnectAlert(est.getStationId())) {
+                        db.insertAlert(est.getStationId(), 0, 0.0,
+                                "Estación desconectada por inactividad");
 
-                    messagingTemplate.convertAndSend("/topic/alertas", alerta);
+                        AlertaDTO alerta = new AlertaDTO();
+                        alerta.setId(0);
+                        alerta.setFecha(new Date());
+                        alerta.setNombreEstacion(est.getStationModel());
+                        alerta.setSensorNombre("N/A");
+                        alerta.setTipoSensor("N/A");
+                        alerta.setValor(0.0);
+                        alerta.setMensaje("Estación desconectada por inactividad");
+
+                        messagingTemplate.convertAndSend("/topic/alertas", alerta);
+                    }
                 }
+            } else {
+                offlineStations.remove(est.getStationId());
             }
         }
     }

--- a/src/main/resources/templates/alertas.html
+++ b/src/main/resources/templates/alertas.html
@@ -134,7 +134,7 @@ function cargarAlertas() {
                 id: a.id,
                 estacion: a.nombreEstacion,
                 sensor: a.sensorNombre || 'N/A',
-                tipo: a.mensaje && a.mensaje.toLowerCase().includes('baja') ? 'BAJA' : 'ALTA',
+                tipo: a.mensaje && a.mensaje.toLowerCase().includes('baj') ? 'BAJA' : 'ALTA',
                 umbral: a.valor,
                 fecha: new Date(a.fecha).toLocaleString(),
                 estado: 'Activo'


### PR DESCRIPTION
## Summary
- track offline stations in memory
- only create and broadcast a disconnection alert when a station first transitions to the offline state
- categorize "baja" alerts correctly on the frontend
- add helper to fetch sensors by id
- broadcast alert rule activations via WebSocket

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6882a4a219e08328b78da479f7973e99