### PR TITLE
Implement alert rule listing API and integrate on dashboard

### DIFF
--- a/src/main/java/org/javadominicano/cmp/DatabaseManager.java
+++ b/src/main/java/org/javadominicano/cmp/DatabaseManager.java
@@ -18,6 +18,9 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class DatabaseManager {
 
     private final String dbUrl;
@@ -669,6 +672,18 @@ public boolean hasDisconnectAlert(int stationId) {
 
     }
 
+    public void deleteAlertRule(int ruleId) {
+        String sql = "DELETE FROM AlertRule WHERE rule_id = ?";
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, ruleId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+    }
+
     public List<AlertRuleDTO> getAlertRuleDTOs() {
         List<AlertRuleDTO> list = new ArrayList<>();
         String sql = """
@@ -691,6 +706,7 @@ public boolean hasDisconnectAlert(int stationId) {
                 dto.setActiva(rs.getBoolean("activa"));
                 dto.setNombreEstacion(rs.getString("station_model"));
                 dto.setSensorNombre(rs.getString("sensor_model"));
+                dto.setFechaCreacion(rs.getTimestamp("fecha_creacion"));
                 list.add(dto);
             }
         } catch (SQLException e) {

--- a/src/main/java/org/javadominicano/cmp/controller/AlertRuleRestController.java
+++ b/src/main/java/org/javadominicano/cmp/controller/AlertRuleRestController.java
@@ -1,0 +1,34 @@
+package org.javadominicano.cmp.controller;
+
+import org.javadominicano.cmp.DatabaseManager;
+import org.javadominicano.cmp.dto.AlertRuleDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class AlertRuleRestController {
+
+    private final DatabaseManager dbManager;
+
+    @Autowired
+    public AlertRuleRestController(DatabaseManager dbManager) {
+        this.dbManager = dbManager;
+    }
+
+    @GetMapping("/api/reglas-alerta")
+    public List<AlertRuleDTO> listarReglas() {
+        return dbManager.getAlertRuleDTOs();
+    }
+
+    @DeleteMapping("/api/reglas-alerta/{id}")
+    public ResponseEntity<Void> eliminarRegla(@PathVariable int id) {
+        dbManager.deleteAlertRule(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/javadominicano/cmp/dto/AlertRuleDTO.java
+++ b/src/main/java/org/javadominicano/cmp/dto/AlertRuleDTO.java
@@ -10,6 +10,7 @@ public class AlertRuleDTO {
     private String tipo;
     private double umbral;
     private boolean activa;
+    private java.util.Date fechaCreacion;
 
     public int getRuleId() {return ruleId;}
     public void setRuleId(int ruleId) {this.ruleId = ruleId;}
@@ -34,4 +35,7 @@ public class AlertRuleDTO {
 
     public boolean isActiva() {return activa;}
     public void setActiva(boolean activa) {this.activa = activa;}
+
+    public java.util.Date getFechaCreacion() {return fechaCreacion;}
+    public void setFechaCreacion(java.util.Date fechaCreacion) {this.fechaCreacion = fechaCreacion;}
 }

--- a/src/main/resources/templates/alertas.html
+++ b/src/main/resources/templates/alertas.html
@@ -127,17 +127,17 @@ function cargarSensores(estacionId) {
 }
 
 function cargarAlertas() {
-    fetch('/api/alertas')
+    fetch('/api/reglas-alerta')
         .then(r => r.json())
         .then(data => {
             alertas = data.map(a => ({
-                id: a.id,
+                id: a.ruleId,
                 estacion: a.nombreEstacion,
                 sensor: a.sensorNombre || 'N/A',
-                tipo: a.mensaje && a.mensaje.toLowerCase().includes('baj') ? 'BAJA' : 'ALTA',
-                umbral: a.valor,
-                fecha: new Date(a.fecha).toLocaleString(),
-                estado: 'Activo'
+                tipo: a.tipo,
+                umbral: a.umbral,
+                fecha: a.fechaCreacion ? new Date(a.fechaCreacion).toLocaleString() : 'N/D',
+                estado: a.activa ? 'Activa' : 'Inactiva'
             }));
             aplicarFiltros();
         });
@@ -157,6 +157,13 @@ function conectarWS() {
 function renderTabla(datos) {
     const tbody = document.querySelector('#alertTable tbody');
     tbody.innerHTML = '';
+    if(datos.length === 0) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = '<td colspan="8">No hay alertas registradas</td>';
+        tbody.appendChild(tr);
+        renderPaginacion(0);
+        return;
+    }
     const start = (currentPage-1)*rowsPerPage;
     const pageData = datos.slice(start, start+rowsPerPage);
     pageData.forEach(a => {
@@ -190,7 +197,7 @@ function renderPaginacion(total) {
 }
 
 function eliminarAlerta(id) {
-  fetch(`/alertas/${id}`, { method: 'DELETE' })
+  fetch(`/api/reglas-alerta/${id}`, { method: 'DELETE' })
     .then(res => {
       if(res.ok) {
         alert('✅ Alerta eliminada');

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -143,6 +143,7 @@ function cargarDashboard() {
                         <li>💧 Humedad: ${est.data?.humedad ?? 'N/D'} %</li>
                         <li>⬇️ Presión: ${est.data?.presion ?? 'N/D'} hPa</li>
                         <li>💨 Viento: ${est.data?.viento ?? 'N/D'} m/s</li>
+                        <li>🌬️ Dirección Viento: ${est.data?.direccion_viento ?? 'N/D'} °</li>
                         <li>🌧️ Precipitación: ${est.data?.precipitacion ?? 'N/D'} mm</li>
                         <li>🌱 Humedad Suelo: ${est.data?.humedad_suelo ?? 'N/D'} %</li>
                     </ul>
@@ -204,6 +205,7 @@ function actualizarUIEstacion(dto) {
             <li>💧 Humedad: ${dto.data?.humedad ?? 'N/D'} %</li>
             <li>⬇️ Presión: ${dto.data?.presion ?? 'N/D'} hPa</li>
             <li>💨 Viento: ${dto.data?.viento ?? 'N/D'} m/s</li>
+            <li>🌬️ Dirección Viento: ${dto.data?.direccion_viento ?? 'N/D'} °</li>
             <li>🌧️ Precipitación: ${dto.data?.precipitacion ?? 'N/D'} mm</li>
             <li>🌱 Humedad Suelo: ${dto.data?.humedad_suelo ?? 'N/D'} %</li>
         </ul>`;


### PR DESCRIPTION
## Summary
- expose new `/api/reglas-alerta` REST endpoint
- add deletion API for alert rules
- include rule creation date in `AlertRuleDTO`
- use new endpoint from alert management page and show message when table is empty

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68891cd34cfc8328932c353db618a9b7