### PR TITLE
Add auto send readings to external hub

### DIFF
--- a/src/main/java/org/javadominicano/cmp/DatabaseManager.java
+++ b/src/main/java/org/javadominicano/cmp/DatabaseManager.java
@@ -12,6 +12,7 @@ import org.javadominicano.cmp.dto.ReporteResumenDTO;
 
 import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.HashMap;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -21,12 +22,16 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+// Servicio para publicar lecturas en el HUB externo
+import org.javadominicano.cmp.ExternalApiService;
+
 @Service
 public class DatabaseManager {
 
     private final String dbUrl;
     private final String dbUser;
     private final String dbPass;
+    private final ExternalApiService externalApi = new ExternalApiService();
 
     public DatabaseManager() {
         this("jdbc:mysql://192.168.100.168/MqttBase", "usermqtt", "Mqtt1234!");
@@ -244,12 +249,29 @@ public void insertRecord(int sensorId, double value, Date date) {
                     insertStmt.setDouble(2, value);
                     insertStmt.setTimestamp(3, new java.sql.Timestamp(date.getTime()));
                     insertStmt.executeUpdate();
+                    enviarAlHub(sensorId, value, date);
                 }
             } else {
                 System.out.println("⚠️ Registro ignorado: sensor deshabilitado (ID=" + sensorId + ")");
             }
         }
     } catch (SQLException e) {
+        e.printStackTrace();
+    }
+}
+
+private void enviarAlHub(int sensorId, double value, Date date) {
+    try {
+        SensorModel sensor = getSensorById(sensorId);
+        if (sensor == null) return;
+
+        Map<String, Object> data = new HashMap<>();
+        String tipo = sensor.getSensorType().toLowerCase().trim().replace("ó", "o");
+        data.put(tipo, value);
+
+        externalApi.sendReading("3", String.valueOf(sensor.getStationId()), date, data);
+    } catch (Exception e) {
+        System.out.println("❌ Error enviando al HUB:");
         e.printStackTrace();
     }
 }

--- a/src/main/java/org/javadominicano/cmp/ExternalApiService.java
+++ b/src/main/java/org/javadominicano/cmp/ExternalApiService.java
@@ -1,0 +1,66 @@
+package org.javadominicano.cmp;
+
+import com.google.gson.Gson;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Servicio utilitario para enviar lecturas al HUB externo.
+ */
+public class ExternalApiService {
+
+    private static final String API_URL = "https://itt363-hub.smar.com.do/api/";
+    private static final String TOKEN = "p7tWxFnpMfPE";
+    private static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final Gson gson = new Gson();
+
+    /**
+     * Envía una lectura al HUB.
+     *
+     * @param group   identificador de grupo
+     * @param station identificador de estación
+     * @param date    fecha de la lectura
+     * @param data    mapa con el tipo de sensor y su valor
+     */
+    public void sendReading(String group, String station, Date date, Map<String, Object> data) {
+        try {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("grupo", group);
+            payload.put("estacion", station);
+            payload.put("fecha", FORMATTER.format(date.toInstant()
+                    .atZone(ZoneId.systemDefault()).toLocalDateTime()));
+            payload.putAll(data);
+
+            String json = gson.toJson(payload);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(API_URL))
+                    .header("SEGURIDAD-TOKEN", TOKEN)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8))
+                    .build();
+
+            httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenAccept(r -> System.out.println("\u2705 Lectura enviada al HUB, status " + r.statusCode()))
+                    .exceptionally(e -> {
+                        System.out.println("\u274C Error enviando al HUB: " + e.getMessage());
+                        return null;
+                    });
+
+        } catch (Exception e) {
+            System.out.println("\u274C Error preparando envío al HUB:");
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- send sensor readings to the ITT363 HUB after they are stored
- create `ExternalApiService` to call the HUB API

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6889f2d4d3fc83288dbdc129958182a3