### PR TITLE
Fix alert thresholds

### DIFF
--- a/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
+++ b/src/main/java/org/javadominicano/cmp/SuscriptorCallback.java
@@ -123,13 +123,13 @@ public class SuscriptorCallback implements MqttCallback {
                     }
 
                     cumple = "ALTA".equals(tipo)
-                            ? valor >= regla.getUmbral()
-                            : valor <= regla.getUmbral();
+                            ? valor > regla.getUmbral()
+                            : valor < regla.getUmbral();
 
                     if (cumple && !regla.isActiva()) {
                         String msg = "ALTA".equals(tipo)
                                 ? "Umbral alto superado"
-                                : "Umbral bajo alcanzado";
+                                : "Umbral bajo superado";
 
                         dbFisico.insertAlert(stationId, sensorId, valor, msg);
                         dbFisico.updateAlertRuleState(regla.getRuleId(), true);

--- a/src/main/java/org/javadominicano/cmp/config/AlertRuleChecker.java
+++ b/src/main/java/org/javadominicano/cmp/config/AlertRuleChecker.java
@@ -31,11 +31,11 @@ public class AlertRuleChecker {
             RecordModel last = db.getLastRecord(r.getSensorId());
             if (last == null) continue;
             boolean cumple = "ALTA".equalsIgnoreCase(r.getTipo())
-                    ? last.getValue() >= r.getUmbral()
-                    : last.getValue() <= r.getUmbral();
+                    ? last.getValue() > r.getUmbral()
+                    : last.getValue() < r.getUmbral();
             if (cumple && !r.isActiva()) {
                 String msg = "ALTA".equalsIgnoreCase(r.getTipo())
-                        ? "Umbral alto superado" : "Umbral bajo alcanzado";
+                        ? "Umbral alto superado" : "Umbral bajo superado";
                 db.insertAlert(r.getStationId(), r.getSensorId(), last.getValue(), msg);
                 db.updateAlertRuleState(r.getRuleId(), true);
 


### PR DESCRIPTION
## Summary
- trigger ALTA alerts when value is strictly greater than the threshold
- trigger BAJA alerts when value is strictly lower than the threshold
- clarify alert messages when thresholds are crossed

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_688aa51fc0448328b723a0fb50a3c758