### PR TITLE
Add external hub reading send method

### DIFF
--- a/src/main/java/org/javadominicano/cmp/ExternalApiService.java
+++ b/src/main/java/org/javadominicano/cmp/ExternalApiService.java
@@ -1,6 +1,9 @@
 package org.javadominicano.cmp;
 
 import com.google.gson.Gson;
+
+// Clase que representa una lectura de sensor
+import org.javadominicano.cmp.Sensor;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -71,6 +74,72 @@ public class ExternalApiService {
 
         } catch (Exception e) {
             System.out.println("\u274C Error preparando envío al HUB:");
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Envia una lectura completa al HUB externo utilizando los datos del objeto Sensor.
+     *
+     * @param sensor lectura a enviar
+     */
+    public void enviarLecturaAHubExterno(Sensor sensor) {
+        if (sensor == null) {
+            return;
+        }
+
+        if (sensor.getFecha() == null) {
+            System.out.println("\u274C Fecha nula, no se envía al HUB externo");
+            return;
+        }
+
+        if (sensor.getTemperatura() == null && sensor.getHumedad() == null) {
+            System.out.println("\u274C Temperatura y humedad nulas, no se envía al HUB externo");
+            return;
+        }
+
+        try {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("grupo", GROUP);
+
+            String estacion = "1";
+            String id = sensor.getSensorId();
+            if (id != null && id.contains("2")) {
+                estacion = "2";
+            }
+            payload.put("estacion", estacion);
+
+            payload.put(
+                    "fecha",
+                    FORMATTER.format(sensor.getFecha().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime())
+            );
+
+            if (sensor.getTemperatura() != null) {
+                payload.put("temperatura", sensor.getTemperatura());
+            }
+            if (sensor.getHumedad() != null) {
+                payload.put("humedad", sensor.getHumedad());
+            }
+
+            String json = gson.toJson(payload);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(API_URL))
+                    .header("SEGURIDAD-TOKEN", TOKEN)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(json, StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200 || response.statusCode() == 201) {
+                System.out.println("\u2705 Envío al HUB externo exitoso (" + response.statusCode() + ")");
+            } else {
+                System.out.println("\u274C Error enviando al HUB externo: HTTP " + response.statusCode());
+            }
+
+        } catch (Exception e) {
+            System.out.println("\u274C Error enviando al HUB externo:");
             e.printStackTrace();
         }
     }

--- a/src/main/java/org/javadominicano/cmp/Sensor.java
+++ b/src/main/java/org/javadominicano/cmp/Sensor.java
@@ -5,7 +5,8 @@ import java.util.Date;
 public class Sensor {
     private String sensorId;
     private String sensorType;
-    private double temperatura;
+    private Double temperatura;
+    private Double humedad;
     private Date fecha;
     private String unidad;
 
@@ -14,8 +15,14 @@ public class Sensor {
     public Sensor(String sensorId, String sensorType) {
         this.sensorId = sensorId;
         this.sensorType = sensorType;
-        this.temperatura = Math.random() * 20 + 15;
         this.fecha = new Date();
+
+        switch (sensorType.toLowerCase()) {
+            case "temperatura" -> this.temperatura = Math.random() * 20 + 15;
+            case "humedad" -> this.humedad = Math.random() * 40 + 40;
+            default -> this.temperatura = Math.random() * 20 + 15;
+        }
+
         this.unidad = switch (sensorType.toLowerCase()) {
             case "temperatura" -> "\u00B0C";
             case "humedad" -> "%";
@@ -31,8 +38,11 @@ public class Sensor {
     public String getSensorType() { return sensorType; }
     public void setSensorType(String sensorType) { this.sensorType = sensorType; }
 
-    public double getTemperatura() { return temperatura; }
-    public void setTemperatura(double temperatura) { this.temperatura = temperatura; }
+    public Double getTemperatura() { return temperatura; }
+    public void setTemperatura(Double temperatura) { this.temperatura = temperatura; }
+
+    public Double getHumedad() { return humedad; }
+    public void setHumedad(Double humedad) { this.humedad = humedad; }
 
     public Date getFecha() { return fecha; }
     public void setFecha(Date fecha) { this.fecha = fecha; }


### PR DESCRIPTION
## Summary
- support humidity data in `Sensor`
- add `enviarLecturaAHubExterno` helper in `ExternalApiService` to send readings to external HUB

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b5f5ffb008328a6c49437f3c326a2