### PR TITLE
Add threshold banner timer

### DIFF
--- a/src/main/java/org/javadominicano/cmp/DatabaseManager.java
+++ b/src/main/java/org/javadominicano/cmp/DatabaseManager.java
@@ -263,12 +263,17 @@ public void insertRecord(int sensorId, double value, Date date) {
 private void enviarAlHub(int sensorId, double value, Date date) {
     try {
         SensorModel sensor = getSensorById(sensorId);
-        if (sensor == null) return;
+        if (sensor == null || sensor.getSensorType() == null) {
+            return;
+        }
+
+        String tipo = sensor.getSensorType().toLowerCase().trim();
+        if (!"temperatura".equals(tipo) && !"humedad".equals(tipo)) {
+            return; // solo enviar temperatura u humedad
+        }
 
         Map<String, Object> data = new HashMap<>();
-        String tipo = sensor.getSensorType().toLowerCase().trim().replace("ó", "o");
         data.put(tipo, value);
-
         externalApi.sendReading(date, data);
     } catch (Exception e) {
         System.out.println("❌ Error enviando al HUB:");

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -85,6 +85,32 @@ function mostrarBanner(nombre) {
     </div>`;
 }
 
+function mostrarAlertaBanner(alerta) {
+    const cont = document.getElementById('alert-banner');
+    const mensaje = alerta.mensaje ? alerta.mensaje.toLowerCase() : '';
+    const esUmbral = mensaje.includes('umbral alto') || mensaje.includes('umbral bajo');
+    const duracion = esUmbral ? 10000 : 4000;
+    const tipo = mensaje.includes('umbral alto') ? 'danger' : 'warning';
+    const icono = tipo === 'danger' ? '🚨' : '⚠️';
+    const div = document.createElement('div');
+    div.className = `alert alert-${tipo} alert-dismissible fade show`;
+    div.role = 'alert';
+    div.innerHTML = esUmbral ? `
+        ${icono} ¡Alerta activa! Umbral superado para <strong>${alerta.sensorNombre}</strong>
+        en <strong>${alerta.nombreEstacion}</strong> — Valor: <strong>${alerta.valor}</strong>
+        <button type="button" class="btn-close" aria-label="Close"></button>
+    ` : `
+        ${icono} ${alerta.mensaje}
+        <button type="button" class="btn-close" aria-label="Close"></button>
+    `;
+    cont.appendChild(div);
+    const timer = setTimeout(() => div.remove(), duracion);
+    div.querySelector('.btn-close').onclick = () => {
+        clearTimeout(timer);
+        div.remove();
+    };
+}
+
 function ocultarBanner() {
     document.getElementById('alert-banner').innerHTML = '';
 }
@@ -233,6 +259,8 @@ function conectarWS() {
             actualizarResumenGeneral();
             if(a.mensaje === 'Estación desconectada por inactividad') {
                 mostrarBanner(a.nombreEstacion);
+            } else {
+                mostrarAlertaBanner(a);
             }
         });
     });


### PR DESCRIPTION
## Summary
- improve threshold alert banner with customizable duration
- filter external hub forwarding to only temperature or humidity sensors

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688bc6f094e88328a95c5ba32e0ce25b